### PR TITLE
Add initContainer for checking database and make image name more customizable

### DIFF
--- a/limesurvey/Chart.yaml
+++ b/limesurvey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: limesurvey
 description: Limesurvey is the number one open-source survey software.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "5-apache"
 maintainers:
   - email: markus@martialblog.de

--- a/limesurvey/templates/_helpers.tpl
+++ b/limesurvey/templates/_helpers.tpl
@@ -92,3 +92,19 @@ Return the LimeSurvey Secret Name
     {{- printf "%s-app-secrets" (include "limesurvey.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the full URL of the LimeSurvey image (including registry, image and tag)
+*/}}
+{{- define "limesurvey.imageUrl" }}
+{{- $registry := .Values.global.imageRegistry | default .Values.image.registry }}
+{{- $registry = trimSuffix "/" $registry }}
+{{- $image := .Values.image.repository }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- if eq $registry "" -}}
+    {{/* useful when you want to use a locally built image */}}
+    {{- printf "%s:%s" $image $tag -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registry $image $tag -}}
+{{- end -}}
+{{- end }}

--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-db
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "limesurvey.imageUrl" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['/bin/sh', '-c',
           'until nc -z -v -w30 "$DB_HOST" "$DB_PORT"; do
@@ -51,7 +51,7 @@ spec:
               {{- end }}
       containers:
         - name: limesurvey-apache
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "limesurvey.imageUrl" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -27,6 +27,28 @@ spec:
       serviceAccountName: {{ include "limesurvey.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-db
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ['/bin/sh', '-c',
+          'until nc -z -v -w30 "$DB_HOST" "$DB_PORT"; do
+          echo "Info: Waiting for database connection...";
+          sleep 5;
+          done']
+          env:
+            - name: DB_HOST
+              {{- if eq .Values.mariadb.enabled true }}
+              value: {{ include "limesurvey.mariadb.fullname" . }}
+              {{- else }}
+              value: {{ .Values.externalDatabase.host }}
+              {{- end }}
+            - name: DB_PORT
+              {{- if eq .Values.mariadb.enabled true }}
+              value: {{ .Values.mariadb.primary.service.port | quote }}
+              {{- else }}
+              value: {{ .Values.externalDatabase.port | quote }}
+              {{- end }}
       containers:
         - name: limesurvey-apache
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/limesurvey/values.yaml
+++ b/limesurvey/values.yaml
@@ -2,7 +2,11 @@
 
 replicaCount: 1
 
+global:
+  imageRegistry: ""
+
 image:
+  registry: docker.io
   repository: martialblog/limesurvey
   # Specify a imagePullPolicy
   pullPolicy: IfNotPresent


### PR DESCRIPTION
While developing the MariaDB integration, it happened to me several
times that MariaDB takes a while to become available, meanwhile the LS
container is waiting, but then get's shot down again by Kubernetes due
to the liveness probe.
This is especially bad when it happens during the database
initialization or while running migrations.
Thus, we just a separate init container, which will wait forever
without being killed.

Once the upstream LS image has a separate wait-for-db.sh command, we
can use that instead of specifying the shell command directly.

Then I also implemented a more flexible template for generating the full image URL (`{REGISTRY}/{REPOSITORY}:{TAG}`).
See https://github.com/helm/charts/pull/8465/files and https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml#L7 for reference.