### PR TITLE
Specify chart directory for chart-releaser-action

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -34,3 +34,5 @@ jobs:
         uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: '.'


### PR DESCRIPTION
By default, chart-releaser-action looks for Helm charts in "charts/",
we have ours in the top-level directory. Need to explicitly pass this
option.

https://github.com/helm/chart-releaser-action/issues/87