### PR TITLE
Use "main" branch version of chart-releaser-action

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -31,7 +31,8 @@ jobs:
           helm repo update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        # use version >= 1.2.2
+        uses: helm/chart-releaser-action@main
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/limesurvey/ls.values.yaml
+++ b/limesurvey/ls.values.yaml
@@ -1,0 +1,9 @@
+---
+mariadb:
+  enabled: false
+
+limesurvey:
+  debug: 0
+
+persistence:
+  enabled: false

--- a/limesurvey/template.yaml
+++ b/limesurvey/template.yaml
@@ -1,0 +1,214 @@
+---
+# Source: limesurvey/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ls-limesurvey
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: limesurvey/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ls-limesurvey-app-secrets
+  namespace: "jack"
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  limesurvey-admin-password: "YWRtaW4="
+---
+# Source: limesurvey/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ls-limesurvey-db-secrets
+  namespace: "jack"
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  db-password: "eW91ci1zdXBlci1zZWNyZXQtcGFzc3dvcmQ="
+---
+# Source: limesurvey/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ls-limesurvey
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+  finalizers:
+    - kubernetes.io/pvc-protection
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "5Gi"
+---
+# Source: limesurvey/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ls-limesurvey
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+---
+# Source: limesurvey/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ls-limesurvey
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: limesurvey
+      app.kubernetes.io/instance: ls
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: limesurvey
+        app.kubernetes.io/instance: ls
+    spec:
+      serviceAccountName: ls-limesurvey
+      securityContext:
+        fsGroup: 33
+        runAsGroup: 33
+        runAsUser: 33
+      initContainers:
+        - name: wait-for-db
+          image: docker.io/martialblog/limesurvey:5-apache
+          imagePullPolicy: IfNotPresent
+          command: ['/bin/sh', '-c',
+          'until nc -z -v -w30 "$DB_HOST" "$DB_PORT"; do
+          echo "Info: Waiting for database connection...";
+          sleep 5;
+          done']
+          env:
+            - name: DB_HOST
+              value: mariadb.example.com
+            - name: DB_PORT
+              value: "3306"
+      containers:
+        - name: limesurvey-apache
+          image: docker.io/martialblog/limesurvey:5-apache
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {}
+          volumeMounts:
+            - name: storage
+              mountPath: "/var/www/html/upload/"
+          env:
+            - name: DB_TYPE
+              value: mysql
+            - name: DB_HOST
+              value: mariadb.example.com
+            - name: DB_PORT
+              value: "3306"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ls-limesurvey-db-secrets
+                  key: db-password
+            - name: DB_USERNAME
+              value: limesurvey
+            - name: DB_NAME
+              value: limesurvey
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ls-limesurvey-app-secrets
+                  key: limesurvey-admin-password
+            - name: ADMIN_USER
+              value: admin
+            - name: ADMIN_NAME
+              value: Administrator
+            - name: ADMIN_EMAIL
+              value: admin@example.com
+            - name: BASE_URL
+              value: http://localhost:8080
+            - name: PUBLIC_URL
+              value: http://localhost:8080
+            - name: URL_FORMAT
+              value: path
+            - name: SHOW_SCRIPT_NAME
+              value: ""
+            - name: DEBUG
+              value: "0"
+            - name: DEBUG_SQL
+              value: ""
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: ls-limesurvey
+---
+# Source: limesurvey/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "ls-limesurvey-test-connection"
+  labels:
+    helm.sh/chart: limesurvey-0.2.0
+    app.kubernetes.io/name: limesurvey
+    app.kubernetes.io/instance: ls
+    app.kubernetes.io/version: "5-apache"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['ls-limesurvey:80']
+  restartPolicy: Never


### PR DESCRIPTION
There was a bug that prevented the chart-releaser-action from working
with the current directory (".").
This bug was fixed in https://github.com/helm/chart-releaser/pull/83
but no new release has been tagged yet.

Thus, until a new release is out we can either just wait, or use the
branch "main" version in the meantime (though we shouldn't forget to
switch back to a tagged release once that is out).