### PR TITLE
Set default passwords to empty

### DIFF
--- a/limesurvey/README.md
+++ b/limesurvey/README.md
@@ -97,7 +97,7 @@ Please refer to the [values.yaml](./values.yaml) for all possible configuration 
 
 ### LimeSurvey Administrator Password
 
-If the initial Admin Password `limesurvey.admin.password` is not provided it will be set to a random string. You extract the password from the Secret:
+If the initial Admin Password `limesurvey.admin.password` is not provided it will be set to a random string. You can extract the password from the Secret:
 
 ```bash
 kubectl get secrets --template={{.data.limesurvey-admin-password}} | base64 -d

--- a/limesurvey/README.md
+++ b/limesurvey/README.md
@@ -93,6 +93,16 @@ mariadb:
 In both cases the application will automatically be configured to use these credentials.
 Please refer to the [values.yaml](./values.yaml) for all possible configuration values.
 
+## Configuration and installation details
+
+### LimeSurvey Administrator Password
+
+If the initial Admin Password `limesurvey.admin.password` is not provided it will be set to a random string. You extract the password from the Secret:
+
+```bash
+kubectl get secrets --template={{.data.limesurvey-admin-password}} | base64 -d
+```
+
 ## Testing
 
 This Helm chart is tested with [helm unittest](https://github.com/quintush/helm-unittest) ([test format spec](https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md)).

--- a/limesurvey/templates/secrets.yaml
+++ b/limesurvey/templates/secrets.yaml
@@ -12,7 +12,7 @@ data:
   {{- if .Values.limesurvey.admin.password }}
   limesurvey-admin-password: {{ .Values.limesurvey.admin.password | b64enc | quote }}
   {{- else }}
-  limesurvey-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  limesurvey-admin-password: {{ randAlphaNum 15 | b64enc | quote }}
   {{- end }}
   {{- if .Values.limesurvey.encrypt.keypair }}
   limesurvey-encrypt-keypair: {{ .Values.limesurvey.encrypt.keypair | b64enc | quote }}
@@ -42,5 +42,5 @@ metadata:
     {{- include "limesurvey.labels" . | nindent 4 }}
 type: Opaque
 data:
-  db-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  db-password: {{ required "externalDatabase.password is required" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/limesurvey/values.yaml
+++ b/limesurvey/values.yaml
@@ -39,7 +39,7 @@ mariadb:
     # MariaDB custom user name
     username: limesurvey
     # MariaDB custom user password
-    password: "your-super-secret-password"
+    password: null
 
 ## Use an externally provisioned database instance
 ## Ignored when mariadb.enabled is set to true
@@ -54,7 +54,7 @@ externalDatabase:
   username: limesurvey
   # External Database user password
   # (ignored when existingSecret is set)
-  password: "your-super-secret-password"
+  password: null
   # External Database database name
   database: limesurvey
   # Use an existing secret for retrieving the database password.
@@ -66,7 +66,7 @@ limesurvey:
   # LimeSurvey initial Administrator Account
   admin:
     user: admin
-    password: admin
+    password: null
     name: Administrator
     email: admin@example.com
   # LimeSurvey permits the encryption of personal data


### PR DESCRIPTION
just so that there is no chance that anyone will use these.

Fixes #20 (Technically not, but we can't do anything else here)