### PR TITLE
[limesurvey] Update path to MariaDB service port and add default values

### DIFF
--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -45,9 +45,9 @@ spec:
               {{- end }}
             - name: DB_PORT
               {{- if eq .Values.mariadb.enabled true }}
-              value: {{ .Values.mariadb.primary.service.port | quote }}
+              value: {{ coalesce .Values.mariadb.primary.service.ports.mysql .Values.mariadb.primary.service.port 3306 | quote }}
               {{- else }}
-              value: {{ .Values.externalDatabase.port | quote }}
+              value: {{ coalesce .Values.externalDatabase.port 3306 | quote }}
               {{- end }}
       containers:
         - name: limesurvey-apache
@@ -98,9 +98,9 @@ spec:
               {{- end }}
             - name: DB_PORT
               {{- if eq .Values.mariadb.enabled true }}
-              value: {{ .Values.mariadb.primary.service.port | quote }}
+              value: {{ coalesce .Values.mariadb.primary.service.ports.mysql .Values.mariadb.primary.service.port 3306 | quote }}
               {{- else }}
-              value: {{ .Values.externalDatabase.port | quote }}
+              value: {{ coalesce .Values.externalDatabase.port 3306 | quote }}
               {{- end }}
             - name: DB_PASSWORD
               valueFrom:


### PR DESCRIPTION
 - The Bitnami MariaDB Port has moved to primary.service.ports.mysql but still supports primary.service.port.