### PR TITLE
[limesurvey] Set baseUrl/publicURL defaults to empty and fix DB_NAME

### DIFF
--- a/limesurvey/Chart.yaml
+++ b/limesurvey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: limesurvey
 description: Limesurvey is the number one open-source survey software.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "5-apache"
 maintainers:
   - email: markus@martialblog.de

--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -140,18 +140,24 @@ spec:
               value: {{ .Values.limesurvey.admin.email }}
             - name: LISTEN_PORT
               value: {{ .Values.limesurvey.listenPort | quote }}
+            {{- if .Values.limesurvey.baseUrl }}
             - name: BASE_URL
               value: {{ .Values.limesurvey.baseUrl }}
+            {{- end }}
+            {{- if .Values.limesurvey.publicUrl }}
             - name: PUBLIC_URL
               value: {{ .Values.limesurvey.publicUrl }}
+            {{- end }}
             - name: URL_FORMAT
               value: {{ .Values.limesurvey.urlFormat }}
               {{- if eq .Values.limesurvey.tableSession true }}
             - name: TABLE_SESSION
               value: {{ .Values.limesurvey.tableSession }}
               {{- end }}
+            {{- if .Values.limesurvey.showScriptName }}
             - name: SHOW_SCRIPT_NAME
               value: {{ .Values.limesurvey.showScriptName | quote }}
+            {{- end }}
             {{- if (or .Values.limesurvey.encrypt.keypair .Values.limesurvey.existingSecret) }}
             - name: ENCRYPT_KEYPAIR
               valueFrom:

--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
                   {{- end }}
             - name: DB_USERNAME
               {{- if eq .Values.mariadb.enabled true }}
-              value: {{ .Values.mariadb.username }}
+              value: {{ .Values.mariadb.auth.username }}
               {{- else }}
               value: {{ .Values.externalDatabase.username }}
               {{- end }}

--- a/limesurvey/values.yaml
+++ b/limesurvey/values.yaml
@@ -81,8 +81,8 @@ limesurvey:
     secretBoxKey: ""
   existingSecret: null
   listenPort: 8080
-  publicUrl: http://localhost:8080
-  baseUrl: http://localhost:8080
+  publicUrl: ""
+  baseUrl: ""
   urlFormat: "path"
   showScriptName: ""
   # Database table prefix; set this to a single whitespace if you don't want a table prefix.


### PR DESCRIPTION
 - So that users don't have to adjust these when using an Ingress
   And lets be honest who doesn't, they are great

- Fixes database user name value in Deployment. Only worked because the Container Image uses _limesurvey_ by default

Fixes #40 