### PR TITLE
Use ENCRYPT_NONCE and ENCRYPT_SECRET_BOX_KEY as env vars

### DIFF
--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -191,14 +191,14 @@ spec:
                   key: limesurvey-encrypt-secretkey
             {{- end }}
             {{- if (or .Values.limesurvey.encrypt.nonce .Values.limesurvey.existingSecret) }}
-            - name: ENCRYPT_SECRET_KEY
+            - name: ENCRYPT_NONCE
               valueFrom:
                 secretKeyRef:
                   name: {{ include "limesurvey.secretName" . }}
                   key: limesurvey-encrypt-nonce
             {{- end }}
             {{- if (or .Values.limesurvey.encrypt.secretBoxKey .Values.limesurvey.existingSecret) }}
-            - name: ENCRYPT_SECRET_KEY
+            - name: ENCRYPT_SECRET_BOX_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "limesurvey.secretName" . }}


### PR DESCRIPTION
Hey there,

I found an issue with the helm chart. I guess during some copy and paste action, a small mistake happened. For v5 there are now `ENCRYPT_SECRET_BOX_KEY` and `ENCRYPT_NONCE` as new environment variables. But they were both defined as `ENCRYPT_SECRET_KEY`.