### PR TITLE
feat: make external database secret more useful

### DIFF
--- a/limesurvey/templates/deployment.yaml
+++ b/limesurvey/templates/deployment.yaml
@@ -68,14 +68,18 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- if .Values.limesurvey.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
               port: http
+          {{- end }}
+          {{- if .Values.limesurvey.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -120,19 +124,33 @@ spec:
                   {{- if .Values.mariadb.enabled }}
                   key: mariadb-password
                   {{- else }}
-                  key: db-password
+                  key: {{ .Values.externalDatabase.existingSecretConfig.passwordField }}
                   {{- end }}
             - name: DB_USERNAME
               {{- if eq .Values.mariadb.enabled true }}
               value: {{ .Values.mariadb.auth.username }}
               {{- else }}
+                {{- if .Values.externalDatabase.existingSecretConfig.usernameField }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "limesurvey.databaseSecretName" . }}
+                  key: {{ .Values.externalDatabase.existingSecretConfig.usernameField }}
+                {{- else}}
               value: {{ .Values.externalDatabase.username }}
+                {{- end }}
               {{- end }}
             - name: DB_NAME
               {{- if eq .Values.mariadb.enabled true }}
               value: {{ .Values.mariadb.auth.database }}
               {{- else }}
+                {{- if .Values.externalDatabase.existingSecretConfig.databaseField }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "limesurvey.databaseSecretName" . }}
+                  key: {{ .Values.externalDatabase.existingSecretConfig.databaseField}}
+                {{- else }}
               value: {{ .Values.externalDatabase.database }}
+                {{- end }}
               {{- end }}
             - name: DB_TABLE_PREFIX
               value: {{ .Values.limesurvey.tablePrefix | quote }}

--- a/limesurvey/values.yaml
+++ b/limesurvey/values.yaml
@@ -42,22 +42,26 @@ mariadb:
 ## Use an externally provisioned database instance
 ## Ignored when mariadb.enabled is set to true
 externalDatabase:
-  # Type of external database ("mysql" or "psql")
+  # Type of external database ("mysql" or "pgsql")
   type: mysql
   # External Database server host
   host: mariadb.example.com
   # External Database server port
   port: 3306
-  # External Database username
+  # External Database username (use existingSecretConfig.usernameField to load from secret)
   username: limesurvey
   # External Database user password
-  # (ignored when existingSecret is set)
+  # (ignored when existingSecret is set, use existingSecretConfig.passwordField to change key)
   password: null
-  # External Database database name
+  # External Database database name (use existingSecretConfig.databaseField to load from secret)
   database: limesurvey
   # Use an existing secret for retrieving the database password.
-  # The secret must contain the field "db-password".
+  # The secret must contain the field "db-password" (field name configurable via existingSecretConfig.passwordField)
   existingSecret: null
+  existingSecretConfig:
+    passwordField: db-password
+    usernameField: null
+    databaseField: null
 
 # Limesurvey Application configuration
 limesurvey:
@@ -76,6 +80,7 @@ limesurvey:
     publicKey: ""
     secretKey: ""
     nonce: ""
+    # Create with: php -r "var_dump(sodium_bin2hex(sodium_crypto_secretbox_keygen()));"
     secretBoxKey: ""
   existingSecret: null
   listenPort: 8080
@@ -93,6 +98,11 @@ limesurvey:
   debugSql: 0
   # Value should be either MyISAM or InnoDB
   mysqlEngine: MyISAM
+  # Probes, disable them when you enable global ssl enforcement, because they won't work with the redirect to https
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
- Make it possible to disable liveness and readiness probes because in some scenarios they do more harm than good
- Make it possible to specify and use also username and db-name from the database secret with customizable keys (this enables using database operators more easily)
- Fixes typo in comment for externalDatabase.type