### PR TITLE
chore: limesurvey upgrades

### DIFF
--- a/limesurvey/Chart.yaml
+++ b/limesurvey/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: limesurvey
 description: Limesurvey is the number one open-source survey software.
 type: application
-version: 0.8.0
-appVersion: "5-apache"
+version: 0.9.0
+appVersion: "6-apache"
 maintainers:
   - email: markus@martialblog.de
     name: martialblog

--- a/limesurvey/README.md
+++ b/limesurvey/README.md
@@ -164,7 +164,7 @@ kubectl get secrets --template={{.data.limesurvey-admin-password}} | base64 -d
 
 ### To 0.9.0
 
-This release bumps the nextcloud container used. Limesurvey 5 is the new LTS. [Follow the official instructions for more information.](https://manual.limesurvey.org/Upgrading_from_a_previous_version)
+This release bumps the LimeSurvey container used. LimeSurvey 5 is the new LTS. [Follow the official instructions for more information.](https://manual.limesurvey.org/Upgrading_from_a_previous_version)
 
 ### To 0.6.0
 

--- a/limesurvey/README.md
+++ b/limesurvey/README.md
@@ -41,7 +41,7 @@ It also packages the [Bitnami MariaDB chart](https://artifacthub.io/packages/hel
 | ------------------- | ---------------------------------------------------- | --------------------- |
 | `image.registry`    | LimeSurvey image registry                            | `docker.io`           |
 | `image.repository`  | LimeSurvey image repository                           | `martialblog/limesurvey`   |
-| `image.tag`         | LimeSurvey image tag (immutable tags are recommended) | `5-apache` |
+| `image.tag`         | LimeSurvey image tag (immutable tags are recommended) | `6-apache` |
 | `image.pullPolicy`  | LimeSurvey image pull policy                          | `IfNotPresent`        |
 | `image.pullSecrets` | LimeSurvey image pull secrets                         | `[]`                  |
 
@@ -126,6 +126,7 @@ It also packages the [Bitnami MariaDB chart](https://artifacthub.io/packages/hel
 LimeSurvey requires a [MySQL- or PostgreSQL-compatible database](https://manual.limesurvey.org/Installation_-_LimeSurvey_CE#Create_a_database_user).
 
 You can either provide your own:
+
 ```yaml
 externalDatabase:
   host: hostname.example
@@ -135,6 +136,7 @@ externalDatabase:
 ```
 
 or you can let the Helm chart provision one for you (based on [Bitnami MariaDB Helm chart](https://artifacthub.io/packages/helm/bitnami/mariadb)):
+
 ```yaml
 mariadb:
   enabled: true
@@ -159,6 +161,10 @@ kubectl get secrets --template={{.data.limesurvey-admin-password}} | base64 -d
 ```
 
 ## Upgrading
+
+### To 0.9.0
+
+This release bumps the nextcloud container used. Limesurvey 5 is the new LTS. [Follow the official instructions for more information.](https://manual.limesurvey.org/Upgrading_from_a_previous_version)
 
 ### To 0.6.0
 


### PR DESCRIPTION
- make 6-apache the default tag (I've read the release notes and apart from themes there should be no breaking changes)

I will be running my own branch in production for the time being, but am hopeful we can figure out a way to merge this and keep this repository a central place for limesurvey.