### PR TITLE
Updatedthe template to use limesurvey.existingSecret

### DIFF
--- a/limesurvey/templates/_helpers.tpl
+++ b/limesurvey/templates/_helpers.tpl
@@ -86,6 +86,8 @@ Return the LimeSurvey Secret Name
 {{- define "limesurvey.secretName" -}}
 {{- if .Values.existingSecret }}
     {{- printf "%s" .Values.existingSecret -}}
+{{- else if .Values.limesurvey.existingSecret }}
+    {{- printf "%s" .Values.limesurvey.existingSecret -}}
 {{- else -}}
     {{- printf "%s-app-secrets" (include "limesurvey.fullname" .) -}}
 {{- end -}}


### PR DESCRIPTION
Updated the template to use `.Values.limesurvey.existingSecret` if set. The root-level `existingSecret` is still prioritized, ensuring backward compatibility for existing users. Previously, the template was incorrectly only checking for `existingSecret` at the root level, despite the associated value being located under the `limesurvey.existingSecret` path in the values.yaml file.